### PR TITLE
Driving force and positive ions

### DIFF
--- a/basic_calculations/basic_calculations_lecture.tex
+++ b/basic_calculations/basic_calculations_lecture.tex
@@ -68,8 +68,8 @@ flow out of the cell.  When $V < E$, positive ions flow into the cell.
 This means that $V$ is driven towards $E$.  Thus, we sometimes refer
 to the quantity $(V - E)$ as the \textit{driving force} across the
 cell membrane.  When the driving force is negative, positive ions are
-driven out of the cell.  When the driving force is positive, positive
-ions are pulled into the cell.
+pulled into the cell.  When the driving force is positive, positive
+ions are driven out the cell.
 
 \paragraph{External current.}  The second component of current is current that is injected into the neuron from external sources (e.g. if we stick an electrode into the neuron and pump in current).  
 


### PR DESCRIPTION
When the driving force is negative, that's mean that the membrane potential is smaller that equilibrium potential. So, the positive ions tend to influx into the cell. and vice verse.